### PR TITLE
include stone to app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-  // implementation project(":stone")
+  implementation project(":stone")
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'androidx.core:core-ktx:1.5.0'


### PR DESCRIPTION
include stone to app in order to experiments.

background:

I've excluded the stone project from app because I could not build AAR.
But today morning I tried to build AAR with stone included to app, it was OK.